### PR TITLE
🧡Club: Ajout infos Colibris printemps 2019

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -3,6 +3,18 @@ title: Accueil
 layout: home
 backgroundImg: /img/coch-dos.jpg
 slides:
+  - heading: Nouvelle session pour les colibris
+    body: >
+      Une nouvelle session pour les colibris de 10 semaines débutera le **15 avril 2019**
+    buttons:
+    - title: Entraînements
+      url: /club/entrainements/#colibri-2010-2011-2012
+      post: <span class="icon icon-calendar"></span>
+      class: btn-default
+    - title: Inscription
+      url: /club/inscription/
+      post: <span class="icon icon-pencil"></span>
+      class: btn-secondary
   - heading: Club satellite – Lachute
     body: >
       Le Corsaire-Chaparral est heureux de participer au développement de l’athlétisme régional en lançant un nouveau club satellite à Lachute.
@@ -104,3 +116,18 @@ featuredPhotos:
 images:
 - /img/coch-dos.jpg
 ---
+
+
+{{% div class="well well-primary text-center" %}}
+
+<span class="h2">Nouvelle session pour les colibris!</span>
+
+<span class="icon icon-star"></span>
+<span class="icon icon-star"></span>
+<span class="icon icon-star"></span>
+
+
+Une nouvelle sssion de 10 semaines débutera le **samedi 10 avril 2019** et se terminera le **samedi 15 juin 2019**.
+
+<a href="/club/entrainements/#colibri-2010-2011-2012" class="btn btn-default">En savoir plus <span class="icon icon-angle-right"></span></a>
+{{% /div %}}

--- a/content/club/entrainements/_index.md
+++ b/content/club/entrainements/_index.md
@@ -11,6 +11,21 @@ menu:
 layout: single
 ---
 
+{{% div class="well well-primary text-center" %}}
+
+<span class="h2">Nouvelle session pour les colibris!</span>
+
+<span class="icon icon-star"></span>
+<span class="icon icon-star"></span>
+<span class="icon icon-star"></span>
+
+
+Une nouvelle sssion de 10 semaines débutera le **samedi 10 avril 2019** et se terminera le **samedi 15 juin 2019**.
+
+<small>_Voir infos plus bas &darr;_</small>
+
+{{% /div %}}
+
 ## Reprise de la saison 2018-2019
 
 Les entraînements reprendront **samedi 15 septembre 2018** à de 10&nbsp;h&nbsp;30 à 12&nbsp;h exceptionnellement pour toutes les catégories, **sauf pour les minimes** dont l'entraînement sera gardé à **9 h 00**. Un pique-nique sera également organisé après l’entraînement dès midi.
@@ -47,13 +62,9 @@ Lachute, Quebec J8H 1W9
 
 Selon les catégories (voir ci-bas).
 
-{{% div class="alert -primary" %}}
-**Club satellite de Lachute** : les résidents de la région de Lachute qui souhaitent faire de l’athlétisme pendant les mois d’octobre, novembre, décembre, janvier, février, mars devront s’incrire au club régulier et pourront prendre part aux entrainements à Sainte-Thérèse. À partir d’**avril 2019**, les activités à la polyvalente Lavigne reprendront.
-{{% /div %}}
+### Colibri (2010-2011-2012)
 
-### Colibri (2010-2011)
-
-_Une session de 10 semaines pour les colibris débutera à nouveau au printemps 2019. Surveillez notre site web pour connaître la date exacte (avril)._
+<em class="badge badge-primary">Nouveau!</em> Une nouvelle session pour les colibris de 10 semaines recommencera à partir du **samedi 15 avril 2019** et se concluera le **samedi 15 juin 2019** avec une mini-compétition amicale!
 
  - Samedi 9 h à 10 h 30
 

--- a/content/club/entrainements/colibris.md
+++ b/content/club/entrainements/colibris.md
@@ -1,8 +1,8 @@
 ---
 title: Entraînements des colibris
-date: "2018"
+date: "2019"
 description: >
-  Proposition du calendrier d’activité pour les colibris (2010–2011).
+  Calendrier d’activité pour les colibris (2010–2011).
 
 menu:
   main:
@@ -11,6 +11,10 @@ menu:
     title: Colibris
     weight: 10
 ---
+
+## Colibris (2010-2011-2012)
+
+<em class="badge badge-primary">Nouveau!</em> Une nouvelle session pour les colibris de 10 semaines recommencera à partir du **samedi 15 avril 2019** et se concluera le **samedi 15 juin 2019** avec une mini-compétition amicale!
 
 ## Horaire d’entraînement
 
@@ -21,24 +25,3 @@ menu:
 * Christophe Miglierina (entraîneur responsable)
 * Samuel Gougeon
 * Alexandre Lafleur
-
-## Calendrier
-
-Les 10 entraînements ont lieux à la polyvalente Sainte-Thérèse, du **samedi 13 octobre** au **samedi 15 décembre 2018**.
-
-{{% div class="well well-danger" %}}
-**Note** : En raison de la non-disponibilité des plateaux d’entraînement, la séance du samedi 24 novembre sera reportée au **samedi 5 janvier 2019**.
-{{% /div %}}
-
-1. **samedi 13 octobre 2018** : piste extérieure 
-2. **samedi 20 octobre 2018** : piste extérieure
-3. **samedi 27 octobre 2018** : piste extérieure  
-    **dimanche 28 octobre 2018** : course de 1 km « Oasis au parc Équestre de Blainville » pour les moins de 12 ans
-4. **samedi 3 novembre 2018** : gymnase double de la PST 
-5. **samedi 10 novembre 2018** : gymnase double de la PST
-6. **samedi 17 novembre 2018** : gymnase double de la PST
-7. ~~**samedi 24 novembre 2018** : gymnase double de la PST~~ <span class="badge badge-danger">annulée</span> reportée au 5 janvier 2019
-8. **samedi 1er décembre 2018** : gymnase double de la PST
-9. **samedi 8 décembre 2018** : gymnase double de la PST
-10. **samedi 15 décembre 2018** : le [Festival en salle des jeunes](/competitions/festival-en-salle-des-jeunes/) aux gymnases de la PST
-11. **samedi 5 janvier** : REPRISE de la semaine #7, gymnase double de la PST

--- a/content/club/inscription.md
+++ b/content/club/inscription.md
@@ -51,7 +51,7 @@ Veuillez prendre note qu'un rabais est accordé aux familles ayant plus d'un ath
 
 | Catégorie               | Du 1<sup>er</sup> sept. au 31 août | Du 1<sup>er</sup> mars au 31 août |
 | ----------------------- | ---------------------------------- | --------------------------------- |
-| Colibri (2010-2011)     | 84 $ par session                   |                                   |
+| Colibri (2010-2011-2012)| 84 $ par session                   |                                   |
 | Minime (2008-2009)      | 272 $                              | 180 $                             |
 | Benjamine (2006-2007)   | 442 $                              | 292 $                             |
 | Cadettte (2004-2005)    | 480 $                              | 317 $                             |

--- a/themes/hugo-theme-coch/layouts/page/home.html
+++ b/themes/hugo-theme-coch/layouts/page/home.html
@@ -55,6 +55,11 @@
     <div class="container container-full">
       <div class="row">
         <article class="col col-8 tablet-col-12">
+
+          {{ if .Content }}
+          {{ .Content }}
+          {{ end }}
+
           <section>
             <h2>Dernières nouvelles</h2>
 
@@ -88,7 +93,6 @@
               </div>
           {{ end }}
 
-          {{ .Content }}
         </article>
         <aside class="col col-4 tablet-col-12 home-sidebar-container">
           <h2>Photos</h2>


### PR DESCRIPTION
Ajout de la nouvelle session de 10 semaines
du 15 avril au 15 juin 2019

avec une belle bulle orange :)

## THEME

Léger changent dans le template `home.html` :
mettre le contenu de la page d'accueil au-dessus
de la section Nouvelles.

![bulle](https://user-images.githubusercontent.com/9596476/55047309-ab9bd880-501a-11e9-89ce-c6e20103c33f.jpeg)
