### PR TITLE
Mises à jour site web du 7 avril 2019

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -116,10 +116,16 @@ menu:
 #    weight: 0
 #    parent: competitions
 
-  - identifier: resultats
-    title: Résultats
-    url: '/resultats/'
-    weight: 70
+  - identifier: camp-de-jour-highlight
+    title: Camp de jour
+    url: '/camp-de-jour/'
+    weight: 5
+    active: true
+
+#  - identifier: resultats
+#    title: Résultats
+#    url: '/resultats/'
+#    weight: 70
   
 #  - identifier: photos
 #    title: Photos

--- a/content/camp-de-jour/index.md
+++ b/content/camp-de-jour/index.md
@@ -1,0 +1,44 @@
+---
+title: "Camp de jour 2019"
+date: 2019-04-07T13:25:59-04:00
+description: >
+  Le Corsaire-Chaparral offrira un camp de jour spécialisé en athlétisme à l’été 2019.
+---
+
+Les villes de Blainville et de Sainte-Thérèse camps de jour spécialisé en athlétisme.
+Initiation aux diverses disciplines de l’athlétisme.
+
+**Coût**  
+- 120 $ / semaine pour les résidents des villes de **Blainville** et de **Sainte-Thérèse**  
+- 150 $ / semaine pour les **non résidents**
+
+
+**Jour**  
+Lundi au vendredi
+
+**Heure**  
+9h à 16h
+
+**Service de garde**  
+50 $ / semaine (service de garde disponible entre 7h et 9h et
+16h et 18h)  
+Min-Max : 8/20 + liste d’attente
+
+**Lieu**  
+Stade d’athlétisme Richard-Garneau à Ste-Thérèse  
+Remarque : Chaque participant doit avoir des espadrilles.  
+Le port de vêtements appropriés selon la température est recommandé. 
+
+**Âge**  
+8-12 ans (l’enfant doit avoir l’âge au début du camp de jour)
+
+**Semaines**  
+8 camps d’une semaine d’activités, soit :
+- Du 24 juin au 28 juin
+- Du 1 au 5 juillet
+- Du 8 au 12 juillet
+- Du 15 au 19 juillet
+- Du 22 au 26 juillet
+- Du 29 juillet au 2 aout
+- Du 5 au 9 aout
+- Du 12 au 16 aout

--- a/content/club/benevolat.md
+++ b/content/club/benevolat.md
@@ -39,10 +39,12 @@ Pour faire partie de l’équipe, envoie un courriel à [admin@corsaire-chaparra
 | 2018-12-15 | Festival des jeunes Corsaire-Chaparral – [Infos](/competitions/festival-en-salle-des-jeunes) / [Bénévolat](https://campagnes.corsaire-chaparral.org/benevolat-festival-en-salle-coch-2018) |
 | 2019-02-02 | Challenge André-Harel – [Infos](/competitions/challenge-andre-harel/) / [Bénévolat](https://campagnes.corsaire-chaparral.org/benevolat-challenge-andre-harel-2019) |
 | 2019-05-05 | Défi course et marche Desjardins de Ste-Thérèse – [Infos](http://www.circuitendurance.ca/defi-course-et-marche-desjardins/) |
-| 2019-05-22 | Crépuscule COCH (à confirmer) |
+| 2019-05-22 | ~~Crépuscule COCH (à confirmer)~~ |
 | 2019-05-28 | Championnat régional scolaire d’athlétisme RSEQ-LL |
-| 2019-06-05 | Crépuscule COCH (à confirmer) |
+| 2019-06-05 | ~~Crépuscule COCH (à confirmer)~~ |
 | 2019-06-16 | Mini-compétition colibri-minime au stade Richard-Garneau |
-| 2019-06-19 | Crépuscule COCH (à confirmer) |
-| 2019-06-29 | Corsaire-Chaparral Invitation 2019 |
-| 2019-07-31 | Crépuscule COCH (à confirmer) |
+| 2019-06-19 | ~~Crépuscule COCH (à confirmer)~~ |
+| 2019-06-29 | Corsaire-Chaparral Invitation 2019 – [Infos](/competitions/corsaire-chaparral-invitation) |
+| 2019-07-31 | ~~Crépuscule COCH (à confirmer)~~ |
+| 2019-07-05 | Championnats canadiens vétéran 2019 – [Infos](/competitions/championnats-canadiens-veteran-2019/) / [Bénévolat](https://campagnes.corsaire-chaparral.org/benevolat-provinciaux-ete-2019) |
+| 2019-07-06 | Championnats québécois 2019 – [Infos](/competitions/championnats-quebecois-junior-senior-para-2019) / [Bénévolat](https://campagnes.corsaire-chaparral.org/benevolat-provinciaux-ete-2019/) |

--- a/content/competitions/_index.md
+++ b/content/competitions/_index.md
@@ -9,3 +9,8 @@ icon: calendar
 #    url: '/competitions/'
 #    weight: 60
 ---
+
+{{% div class="well well-danger" %}}
+Prenez note que pour l'instant, le Corsaire-Chaparral n'a pas l'intention d'offrir des crépuscules estivaux pour l'été 2019, en raison du manque de disponibilité des officiels.
+
+{{% /div %}}

--- a/content/competitions/championnats-canadiens-veteran-2019.md
+++ b/content/competitions/championnats-canadiens-veteran-2019.md
@@ -1,0 +1,38 @@
+---
+title: "Championnats canadiens vétéran 2019"
+slug: championnats-canadiens-veteran-2019
+date: 2019-07-06
+icon: calendar
+description: >
+  Les championnats canadiens vétéran se tiendront à Sainte-Thérèse du 5 au 7 juillet 2019, concurramment aux [Championnats québécois junior, senior et para](/competitions/championnats-quebecois-junior-senior-para-2019) les 6 et 7 juillet 2019.
+menu:
+  main:
+    identifier: championnats-canadiens-veteran
+    weight: 0
+    parent: competitions
+---
+
+## Informations générales
+
+**Dates :**  
+Vendredi 5, samedi 6 et dimanche 7 juillet 2019
+
+**Emplacement :**  
+Stade d’athlétisme Richard-Garneau  
+```
+401, boul. du Domaine  
+Sainte-Thérèse QC  
+J7E 4S4
+```
+
+**Personnel de contact :**  
+
+- [Robert Lavoie](mailto:robertlecoach@gmail.com), _direction technique_
+- [Samuel Grondin-Bernier](mailto:grondin750@hotmail.com), _direction technique_
+- [Louis-Olivier Brassard](mailto:louis@corsaire-chaparral.org), _chronométrage et résultats_
+
+## Bénévolat
+
+Pour cet événement d’envergure, nous aurons grandement besoin de bénévoles!
+
+Inscrivez-vous via notre formulaire en ligne _(à venir sous peu)_.

--- a/content/competitions/championnats-canadiens-veteran-2019.md
+++ b/content/competitions/championnats-canadiens-veteran-2019.md
@@ -35,4 +35,9 @@ J7E 4S4
 
 Pour cet événement d’envergure, nous aurons grandement besoin de bénévoles!
 
-Inscrivez-vous via notre formulaire en ligne _(à venir sous peu)_.
+Inscrivez-vous via notre formulaire en ligne :
+
+<a href="https://campagnes.corsaire-chaparral.org/benevolat-provinciaux-ete-2019" target="_blank" class="btn btn-primary">
+<span class="icon icon-assignment"></span>
+Formulaire de bénévolat
+</a>

--- a/content/competitions/championnats-quebecois-junior-senior-para-2019.md
+++ b/content/competitions/championnats-quebecois-junior-senior-para-2019.md
@@ -1,0 +1,38 @@
+---
+title: "Championnats québécois junior-senior-para 2019"
+slug: championnats-quebecois-junior-senior-para-2019
+date: 2019-07-06
+icon: calendar
+description: >
+  Les championnats québécois junior, senior et para se tiendront à Sainte-Thérèse du 6 aut 7 juillet 2019, ainsi que les [championnats canadiens vétéran](/competitions/championnats-canadiens-veteran-2019) du 5 au 7 juillet 2019.
+menu:
+  main:
+    identifier: championnats-provinciaux
+    weight: 0
+    parent: competitions
+---
+
+## Informations générales
+
+**Dates :**  
+Samedi 6 et dimanche 7 juillet 2019
+
+**Emplacement :**  
+Stade d’athlétisme Richard-Garneau  
+```
+401, boul. du Domaine  
+Sainte-Thérèse QC  
+J7E 4S4
+```
+
+**Personnel de contact :**  
+
+- [Robert Lavoie](mailto:robertlecoach@gmail.com), _direction technique_
+- [Samuel Grondin-Bernier](mailto:grondin750@hotmail.com), _direction technique_
+- [Louis-Olivier Brassard](mailto:louis@corsaire-chaparral.org), _chronométrage et résultats_
+
+## Bénévolat
+
+Pour cet événement d’envergure, nous aurons grandement besoin de bénévoles!
+
+Inscrivez-vous via notre formulaire en ligne _(à venir sous peu)_.

--- a/content/competitions/championnats-quebecois-junior-senior-para-2019.md
+++ b/content/competitions/championnats-quebecois-junior-senior-para-2019.md
@@ -35,4 +35,9 @@ J7E 4S4
 
 Pour cet événement d’envergure, nous aurons grandement besoin de bénévoles!
 
-Inscrivez-vous via notre formulaire en ligne _(à venir sous peu)_.
+Inscrivez-vous via notre formulaire en ligne :
+
+<a href="https://campagnes.corsaire-chaparral.org/benevolat-provinciaux-ete-2019" target="_blank" class="btn btn-primary">
+<span class="icon icon-assignment"></span>
+Formulaire de bénévolat
+</a>

--- a/content/competitions/corsaire-chaparral-invitation.md
+++ b/content/competitions/corsaire-chaparral-invitation.md
@@ -1,6 +1,6 @@
 ---
 title: Corsaire-Chaparral Invitation
-date: "2018-06-30"
+date: "2019-06-29"
 icon: calendar
 menu:
   main:
@@ -11,27 +11,19 @@ menu:
 
 Le club d'athlétisme Corsaire-Chaparral organise annuellement sa compétition estivale avec, au programme, un ensemble d'épreuves pour les athlètes de catégories benjamine à senior.
 
-Cette compétition tient également lieu de **finale régionale des Laurentides** en vue des Jeux du Québec à Thetford. Pour de plus amples informations concernant les critères de sélection, consultez la section [Jeux du Québec](http://athletisme-quebec.ca/jeux-du-quebec) du site web de la FQA.
-
 ### Informations générales
 
-La rencontre se déroule sur une piste synthétique comportant 8 corridors en courbe et 10 en ligne droite, avec des aires de saut constituées de la même surface de caoutchouc *Regupol*. Deux cages de lancers sont disponibles, ainsi qu'une zone d'échauffement gazonnée à l'extérieur de l'enceinte de compétition.
-
-[Document technique](https://corsaire-chaparral.org/medias/competitions/2018/corsaire-chaparral-invitation-2018-document-technique.pdf) _(mis à jour le 27 juin 2018)_
-
-[Horaire final](https://corsaire-chaparral.org/medias/competitions/2018/coch-invitation-2018.horaire.pdf) _(mis à jour le 28 juin 2018)_
-
-[Liste des performances](https://corsaire-chaparral.org/medias/competitions/2018/coch-invitation-2018.liste-perf.pdf) _(mis à jour le 27 juin 2018)_.
+La rencontre se déroule sur une piste synthétique comportant 8 corridors en courbe et 10 en ligne droite, avec des aires de saut constituées de la même surface de caoutchouc *Regupol*. Deux cages de lancer sont disponibles, ainsi qu'une zone d'échauffement gazonnée à l'extérieur de l'enceinte de compétition.
 
 <!--[Résultats en direct](/resultats/direct)-->
 
-Responsable de la rencontre : [Robert Lavoie](mailto:robertlecoach@gmail.com).
+Responsable de la rencontre : [Samuel Grondin-Bernier](mailto:samuel@corsaire-chaparral.org).
 
 Responsable de la finale régionale des Jeux du Québec : [Louis-Olivier Brassard](mailto:louis@corsaire-chaparral.org)
 
 #### Date
 
-La rencontre aura lieu le **samedi 30 juin 2018**.
+La rencontre aura lieu le **samedi 29 juin 2019**.
 
 #### Emplacement
 
@@ -41,13 +33,11 @@ Sainte-Thérèse, QC J7E 4S4
 
 #### Inscription
 
-Veuillez procéder à l'inscription *via* le site [avs-sport.com](https://www.avs-sport.com/main.php) entre le 8 juin et le 22 juin 2018.
+_À venir_ – veuillez procéder à l'inscription *via* le site [avs-sport.com](https://www.avs-sport.com/main.php).
 
-**Athlètes du Corsaire-Chaparral** : inscrivez-vous via le formulaire qui vous a été envoyé par courriel. Pour toutes questions, adressez-vous à [Nadine Lauzon](mailto:corsairechaparal@hotmail.com).
+<!--Tel que spécifié dans le document technique, les **inscriptions tardives** seront acceptées sur AVS-Sport jusqu’au **lundi 25 juin à 16 h** moyennant des frais de 50 $ par épreuve. Aucune inscription après cette date. Aucune inscription sans paiement.-->
 
-Tel que spécifié dans le document technique, les **inscriptions tardives** seront acceptées sur AVS-Sport jusqu’au **lundi 25 juin à 16 h** moyennant des frais de 50 $ par épreuve. Aucune inscription après cette date. Aucune inscription sans paiement.
-
-## Résultats
+## Résultats antérieurs
 
 [Résultats 2018](/resultats/2018/corsaire-chaparral-invitation/)
 

--- a/content/competitions/crepuscules.md
+++ b/content/competitions/crepuscules.md
@@ -1,12 +1,13 @@
 ---
 title: "Crépuscules estivaux"
-date: "2018"
+date: "2019"
 icon: calendar
 menu:
   main:
     identifier: crepuscules
     weight: 0
     parent: competitions
+published: false
 ---
 
 ## Informations générales

--- a/content/competitions/finale-regionale-jq.md
+++ b/content/competitions/finale-regionale-jq.md
@@ -1,6 +1,6 @@
 ---
 title: "Finale régionale des Jeux du Québec"
-date: "2018-06-30"
+date: "2019-08-03"
 icon: calendar
 menu:
   main:
@@ -10,6 +10,14 @@ menu:
 ---
 
 _Répondant régional pour l'équipe des Laurentides en athlétisme : [Louis-Olivier Brassard](mailto:louis@athlaurentides.ca)_
+
+{{% div class="well well-danger" %}}
+<span class="h2 no-margin"><span class="icon icon-warning"></span> Note</span>
+
+**L’information contenue sur cette page n’est plus à jour**; elle sera éditée sous peu pour l’année 2019.
+
+Un match inter-régions provincial pour les **cadets** se tiendra à Québec le 3 août 2019. 
+{{% /div %}}
 
 En vue de la [53<sup>e</sup> finale provinciale des Jeux du Québec 2018](http://www.jeuxduquebec.com/) à Thetford, le club d'athlétisme Corsaire-Chaparral organisera la finale régionale des Laurentides pour les épreuves d'athlétisme. Cette épreuve servira de qualification pour les athlètes désirant faire partie de la délégation laurentienne à la grande finale provinciale des Jeux.
 

--- a/content/resultats/2014/_index.md
+++ b/content/resultats/2014/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Résultats 2014
 icon: assignment
-menu:
-  main:
-    parent: resultats
-    title: 2014
-    weight: -14
+#menu:
+#  main:
+#    parent: resultats
+#    title: 2014
+#    weight: -14
 ---
 

--- a/content/resultats/2015/_index.md
+++ b/content/resultats/2015/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Résultats 2015
 icon: assignment
-menu:
-  main:
-    parent: resultats
-    title: 2015
-    weight: -15
+#menu:
+#  main:
+#    parent: resultats
+#    title: 2015
+#    weight: -15
 ---
 

--- a/content/resultats/2016/_index.md
+++ b/content/resultats/2016/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Résultats 2016
 icon: assignment
-menu:
-  main:
-    parent: resultats
-    title: 2016
-    weight: -16
+#menu:
+#  main:
+#    parent: resultats
+#    title: 2016
+#    weight: -16
 ---
 

--- a/content/resultats/2017/_index.md
+++ b/content/resultats/2017/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Résultats 2017
 icon: assignment
-menu:
-  main:
-    parent: resultats
-    title: 2017
-    weight: -17
+#menu:
+#  main:
+#    parent: resultats
+#    title: 2017
+#    weight: -17
 ---
 

--- a/content/resultats/2018/_index.md
+++ b/content/resultats/2018/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Résultats 2018
 icon: assignment
-menu:
-  main:
-    parent: resultats
-    title: 2018
-    weight: -18
+#menu:
+#  main:
+#    parent: resultats
+#    title: 2018
+#    weight: -18
 ---
 

--- a/content/resultats/_index.md
+++ b/content/resultats/_index.md
@@ -3,11 +3,12 @@ title: Résultats
 icon: assignment
 #menu:
 #  main:
-#    identifier: resultats
+#    identifier: resultats-collection
 #    title: Résultats
+#    parent: competitions
+#    weight: 10
 #    url: '/resultats/'
-#    weight: 70
-layout: section
+
 ---
 
 <!--[Résultats en direct](direct) _(dernière compétition : Corsaire-Chaparral Invitation)_-->

--- a/data/navigation.yml
+++ b/data/navigation.yml
@@ -12,8 +12,8 @@
   url: "/competitions/"
   subnav: "Compétitions"
 
-- name: "Résultats"
-  url: "/resultats/"
+#- name: "Résultats"
+#  url: "/resultats/"
   
 #- name: "Photos"
 #  url: "/photos/"

--- a/themes/hugo-theme-coch/assets/styles/partials/_nav.scss
+++ b/themes/hugo-theme-coch/assets/styles/partials/_nav.scss
@@ -51,6 +51,11 @@
           color: check-background($color-primary);
         }
       }
+      
+      &.highlight {
+        background-color: $color-primary;
+        color: check-background($color-primary);
+      }
 
       &.active {
         > a {

--- a/themes/hugo-theme-coch/layouts/partials/navbar.html
+++ b/themes/hugo-theme-coch/layouts/partials/navbar.html
@@ -9,7 +9,8 @@
     <ul class="nav nav-break">
       {{ $currentPage := . }}
       {{ range .Site.Menus.main.ByWeight }}
-      <li class="{{if or ($currentPage.IsMenuCurrent "main" . ) ($currentPage.HasMenuCurrent "main" . ) }}active{{ end }}{{ if .HasChildren }} dropdown{{ end }}">
+      <li class="{{if or ($currentPage.IsMenuCurrent "main" . ) ($currentPage.HasMenuCurrent "main" . ) }}active{{ end }}{{ if .HasChildren }} dropdown{{ end }}
+        {{ if findRE "highlight" .Identifier }} highlight{{ end }}">
         <a href="{{ .URL }}">{{ .Title }}{{ if .HasChildren }} <span class="icon icon-angle-down"></span>{{ end }}</a>
         {{ if .HasChildren }}
         <ul class="dropdown-list">


### PR DESCRIPTION
- Ajout d'une page [Camp de jour](https://corsaire-chaparral.org/camp-de-jour/) – Closes #7 
- Ajout d'une page [Championnats quebecois 2019](https://corsaire-chaparral.org/competitions/championnats-quebecois-junior-senior-para-2019/) - Closes #41 
- Ajout d'une page [Championnats canadiens veteran 2019](https://corsaire-chaparral.org/competitions/championnats-canadiens-veteran-2019/) – Closes #41 
- Enlever page crépuscules (ajouté message sur page [Competitions](https://corsaire-chaparral.org/competitions/) – Closes #33
- Mettre à jour 2019 page [Corsaire-Chaparral Invitation](https://corsaire-chaparral.org/competitions/corsaire-chaparral-invitation/) – Closes #31 
- Dans les menus, mettre **Résultats** sous **Compétitions** (faire de la place pour Camp de jour)

